### PR TITLE
Update 1.2.2

### DIFF
--- a/YYCalendar.podspec
+++ b/YYCalendar.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
 	s.name             = 'YYCalendar'
-	s.version          = '1.2.1'
+	s.version          = '1.2.2'
 	s.swift_version    = '5.0'
 	s.summary          = 'Very Simple and Useful Calendar'
 

--- a/YYCalendar/Classes/Components/LimitedCalendar.swift
+++ b/YYCalendar/Classes/Components/LimitedCalendar.swift
@@ -93,7 +93,7 @@ import UIKit
     var maxDate: Date = Date() // limited maximum date
 
     // MARK: - Initialization
-    public init(langType type: LangType, date: String, minDate: String?, maxDate: String?, format: String, completion selectHandler: SelectHandler?) {
+    public init(langType type: LangType, date: String, minDate: String?, maxDate: String?, format: String, completion selectHandler: @escaping SelectHandler) {
         super.init(nibName: nil, bundle: nil)
         self.langType = type
         self.dateFormat = format

--- a/YYCalendar/Classes/Components/NormalCalendar.swift
+++ b/YYCalendar/Classes/Components/NormalCalendar.swift
@@ -91,7 +91,7 @@ import UIKit
     var todayDay: Int = Calendar.current.component(.day, from: Date())
 
     // MARK: - Initialization
-    public init(langType type: LangType, date: String, format: String, completion selectHandler: SelectHandler?) {
+    public init(langType type: LangType, date: String, format: String, completion selectHandler: @escaping SelectHandler) {
         super.init(nibName: nil, bundle: nil)
         self.langType = type
         self.dateFormat = format

--- a/YYCalendar/Classes/YYCalendar.swift
+++ b/YYCalendar/Classes/YYCalendar.swift
@@ -15,12 +15,12 @@ import Foundation
     public var limitedCalendar: LimitedCalendar?
 
     // MARK: - Initialization
-    public init(normalCalendarLangType langType: LangType, date: String, format: String, completion: SelectHandler?) {
+    public init(normalCalendarLangType langType: LangType, date: String, format: String, completion: @escaping SelectHandler) {
         componentType = .normal
         normalCalendar = NormalCalendar.init(langType: langType, date: date, format: format, completion: completion)
     }
 
-    public init(limitedCalendarLangType langType: LangType, date: String, minDate: String?, maxDate: String?, format: String, completion: SelectHandler?) {
+    public init(limitedCalendarLangType langType: LangType, date: String, minDate: String?, maxDate: String?, format: String, completion: @escaping SelectHandler) {
         componentType = .limited
         limitedCalendar = LimitedCalendar.init(langType: langType, date: date, minDate: minDate, maxDate: maxDate, format: format, completion: completion)
     }


### PR DESCRIPTION
### change selectHandler type to escaping closure

- change calendar's selectHandler type from non-escaping closure to escaping closure
refs #21 